### PR TITLE
allow lapacke-static to provide c lapack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,14 @@ rust:
 
 env:
   matrix:
-    - FEATURE=accelerate
+    - FEATURE="accelerate lapacke_static"
     - FEATURE=netlib
     - FEATURE=openblas
 
 matrix:
   exclude:
     - os: linux
-      env: FEATURE=accelerate
+      env: FEATURE="accelerate lapacke_static"
 
 before_install:
   - curl https://stainless-steel.github.io/travis/fortran.sh | bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ default = ["openblas"]
 accelerate = ["accelerate-src"]
 netlib = ["netlib-src"]
 openblas = ["openblas-src"]
+lapacke_static = ["lapacke-static"]
 
 [dependencies]
 libc = "0.2"
@@ -34,4 +35,8 @@ optional = true
 
 [dependencies.openblas-src]
 version = "0.5"
+optional = true
+
+[dependencies.lapacke-static]
+version = "0.1"
 optional = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,9 @@ extern crate libc;
 #[cfg(feature = "accelerate")]
 extern crate accelerate_src as raw;
 
+#[cfg(feature = "lapacke_static")]
+extern crate lapacke_static;
+
 #[cfg(feature = "netlib")]
 extern crate netlib_src as raw;
 
@@ -24,7 +27,7 @@ pub type c_double_complex = [libc::c_double; 2];
 #[allow(bad_style)]
 pub type c_float_complex = [libc::c_float; 2];
 
-#[cfg(not(feature = "accelerate"))]
+#[cfg(any(feature="lapacke_static", feature="netlib", feature="openblas"))]
 pub mod c;
 
 pub mod fortran;


### PR DESCRIPTION
macOS provides Accelerate.framework with only support column-major LAPACK. By depending on the lapacke-static crate, we can get row-major support also on macOS.