### PR TITLE
Intel MKL backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
     - FEATURE=accelerate
     - FEATURE=netlib
     - FEATURE=openblas
+    - FEATURE=intel-mkl
 
 matrix:
   exclude:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ default = ["openblas"]
 accelerate = ["accelerate-src"]
 netlib = ["netlib-src"]
 openblas = ["openblas-src"]
+intel-mkl = ["intel-mkl-src"]
 
 [dependencies]
 libc = "0.2"
@@ -35,4 +36,8 @@ optional = true
 
 [dependencies.openblas-src]
 version = "0.5"
+optional = true
+
+[dependencies.intel-mkl-src]
+version = "0.1"
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,5 +39,5 @@ version = "0.5"
 optional = true
 
 [dependencies.intel-mkl-src]
-version = "0.2.4"
+version = "0.2.5"
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,5 +39,5 @@ version = "0.5"
 optional = true
 
 [dependencies.intel-mkl-src]
-version = "0.2.2"
+version = "0.2.4"
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,5 +39,5 @@ version = "0.5"
 optional = true
 
 [dependencies.intel-mkl-src]
-version = "0.1"
+version = "0.2.1"
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,5 +39,5 @@ version = "0.5"
 optional = true
 
 [dependencies.intel-mkl-src]
-version = "0.2.1"
+version = "0.2.2"
 optional = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,9 @@ extern crate netlib_src as raw;
 #[cfg(feature = "openblas")]
 extern crate openblas_src as raw;
 
+#[cfg(feature = "intel-mkl")]
+extern crate intel_mkl_src as raw;
+
 /// A complex number with 64-bit parts.
 #[allow(bad_style)]
 pub type c_double_complex = [libc::c_double; 2];


### PR DESCRIPTION
Recently I created [intel-mkl-src](https://github.com/termoshtt/rust-intel-mkl) crate to use Intel MKL in Rust  easily. It is still experimental and only supports static link, but I confirmed it works with [ndarray-linalg](https://github.com/termoshtt/ndarray-linalg) in my machine (Arch Linux).
I extract the static library (and compressed by xz) from the official package for Linux, and thus I expect that it does not works on other platforms.